### PR TITLE
Adds a notebook (for Jupyter docker stack environment) to run the lisc demos

### DIFF
--- a/lisc/collect/__init__.py
+++ b/lisc/collect/__init__.py
@@ -1,4 +1,4 @@
 from .info import collect_info
 from .words import collect_words
 from .counts import collect_counts
-from .citations import collect_citations
+from .citations import collect_citations, collect_citation_dois

--- a/lisc/collect/citations.py
+++ b/lisc/collect/citations.py
@@ -77,3 +77,78 @@ def get_citation_data(req, citation_url):
         n_citations = None
 
     return n_citations
+
+
+def collect_citation_dois(dois, util='citations', logging=None, directory=None, verbose=False):
+    """Collect a list of DOIs citing the target(s) using OpenCitations.
+
+    Parameters
+    ----------
+    dois : list of str
+        DOIs to collect citation data for.
+    util : {'citations', 'references'}
+        Which utility to collect citation data with. Options:
+
+        * 'citations': collects the number of citations citing the specified DOI.
+        * 'references': collects the number of references cited by the specified DOI.
+    logging : {None, 'print', 'store', 'file'}, optional
+        What kind of logging, if any, to do for requested URLs.
+    directory : str or SCDB, optional
+        Folder or database object specifying the save location.
+    verbose : bool, optional, default: False
+        Whether to print out updates.
+
+    Returns
+    -------
+    citations : dict
+        The number of citations for each DOI.
+    meta_data : MetaData
+        Meta data about the data collection.
+    """
+
+    urls = OpenCitations()
+    urls.build_url(util)
+
+    meta_data = MetaData()
+    req = Requester(wait_time=0.1, logging=logging, directory=directory)
+
+    if verbose:
+        print('Collecting citation data.')
+
+    citations = {doi : get_citation_doi_data(req, urls.get_url(util, [doi])) for doi in dois}
+
+    meta_data.add_requester(req)
+
+    return citations, meta_data
+
+
+def get_citation_doi_data(req, citation_url):
+    """Extract the number of citations from an OpenCitations URL request.
+
+    Parameters
+    ----------
+    req : Requester
+        Requester to launch requests from.
+    citation_url : str
+        URL to collect citation data from.
+
+    Returns
+    -------
+   citations : list of strings
+        The DOIs of articles citing the target article.
+    """
+
+    page = req.request_url(citation_url)
+    jpage = json.loads(page.content.decode('utf-8'))
+    n_citations = len(jpage)
+
+    # If the return is empty, encode as None instead of zero
+    #   This is because we don't want to treat missing data as 0 citations
+    if n_citations == 0:
+        citations = None
+    else:
+        citations = [ acite['citing'] for acite in jpage]
+
+    return citations
+
+

--- a/tutorials/Run the lisc demos.ipynb
+++ b/tutorials/Run the lisc demos.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run LISC demos inside a Jupyter docker stack\n",
+    "This notebook assumes you're running inside a *scipy-notebook* or *datascience-notebook* environment from the official Project Jupyter docker stacks.  It will install the necessary pip packages and execute the LISC demos, showing the results of each demo.\n",
+    "\n",
+    "To run this notebook, the docker command I use is\n",
+    "\n",
+    "    > docker run --rm -e NB_UID=$(id -u) -e NB_GID=$(id -g) --user root -p 8888:8888 -v /local/path/to/your/code:/home/jovyan/code  jupyter/scipy-notebook\n",
+    "    \n",
+    "NB: \n",
+    "- the --rm argument removes the image when the execution is done, all work is gone unless you save it on a local directory!\n",
+    "- the -v argument links a local directory into the docker image so you can load/save work there\n",
+    "- the -e arguments make sure that your user/group ID is used to read/write in the local directory\n",
+    "\n",
+    "Obviously, very old versions or distant future versions of docker or the Jupyter docker stack may require changes to this method!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "!{sys.executable} -m pip install wordcloud\n",
+    "!{sys.executable} -m pip install lisc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run plot_00-Overview.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run plot_01-CountsCollection.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run plot_02-CountsAnalysis.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run plot_03-WordsCollection.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# necessary for plot_04 work\n",
+    "import nltk\n",
+    "nltk.download('punkt')\n",
+    "nltk.download('stopwords')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run plot_04-WordsAnalysis.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run plot_05-Citations.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run plot_06-MetaData.py"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tutorials/Run the lisc demos.ipynb
+++ b/tutorials/Run the lisc demos.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# Run LISC demos inside a Jupyter docker stack\n",
+    "\n",
     "This notebook assumes you're running inside a *scipy-notebook* or *datascience-notebook* environment from the official Project Jupyter docker stacks.  It will install the necessary pip packages and execute the LISC demos, showing the results of each demo.\n",
     "\n",
     "To run this notebook, the docker command I use is\n",
@@ -16,7 +17,9 @@
     "- the -v argument links a local directory into the docker image so you can load/save work there\n",
     "- the -e arguments make sure that your user/group ID is used to read/write in the local directory\n",
     "\n",
-    "Obviously, very old versions or distant future versions of docker or the Jupyter docker stack may require changes to this method!"
+    "Obviously, very old versions or distant future versions of docker or the Jupyter docker stack may require changes to this method!\n",
+    "\n",
+    "## Of course this would run just fine in any python environment that has the lisc dependencies installed.  In that case skip the first cell \"import sys\" etc..."
    ]
   },
   {


### PR DESCRIPTION
Obviously you could run it in any similar python environment as well. 

I did this because it took me a more than a few minutes to figure out the dependencies like wordcloud and nltk downloads.  It's iterative... run a demo, watch it fail, fix with the right command, do it again for the next failure.  If a new user has a python environment without these dependencies preinstalled this will save some time/effort for them.  