### PR TITLE
added ability to collect DOIs of citing papers using OpenCitations

### DIFF
--- a/lisc/collect/__init__.py
+++ b/lisc/collect/__init__.py
@@ -1,4 +1,4 @@
 from .info import collect_info
 from .words import collect_words
 from .counts import collect_counts
-from .citations import collect_citations, collect_citation_dois
+from .citations import collect_citations

--- a/lisc/collect/__init__.py
+++ b/lisc/collect/__init__.py
@@ -1,4 +1,4 @@
 from .info import collect_info
 from .words import collect_words
 from .counts import collect_counts
-from .citations import collect_citations
+from .citations import collect_citations, collect_citation_dois

--- a/lisc/collect/citations.py
+++ b/lisc/collect/citations.py
@@ -77,3 +77,78 @@ def get_citation_data(req, citation_url):
         n_citations = None
 
     return n_citations
+
+
+def collect_citation_dois(dois, util='citations', logging=None, directory=None, verbose=False):
+    """Collect a list of DOIs citing the target(s) using OpenCitations.
+
+    Parameters
+    ----------
+    dois : list of str
+        DOIs to collect citation data for.
+    util : {'citations', 'references'}
+        Which utility to collect citation data with. Options:
+
+        * 'citations': collects the number of citations citing the specified DOI.
+        * 'references': collects the number of references cited by the specified DOI.
+    logging : {None, 'print', 'store', 'file'}, optional
+        What kind of logging, if any, to do for requested URLs.
+    directory : str or SCDB, optional
+        Folder or database object specifying the save location.
+    verbose : bool, optional, default: False
+        Whether to print out updates.
+
+    Returns
+    -------
+    citations : dict
+        The number of citations for each DOI.
+    meta_data : MetaData
+        Meta data about the data collection.
+    """
+
+    urls = OpenCitations()
+    urls.build_url(util)
+
+    meta_data = MetaData()
+    req = Requester(wait_time=0.1, logging=logging, directory=directory)
+
+    if verbose:
+        print('Collecting citation data.')
+
+    citations = {doi : get_citation_doi_data(req, urls.get_url(util, [doi])) for doi in dois}
+
+    meta_data.add_requester(req)
+
+    return citations, meta_data
+
+
+def get_citation_doi_data(req, citation_url):
+    """Extract the number of citations from an OpenCitations URL request.
+
+    Parameters
+    ----------
+    req : Requester
+        Requester to launch requests from.
+    citation_url : str
+        URL to collect citation data from.
+
+    Returns
+    -------
+   citations : list of strings
+        The DOIs of articles citing the target article.
+    """
+
+    page = req.request_url(citation_url)
+    jpage = json.loads(page.content.decode('utf-8'))
+    n_citations = len(jpage)
+
+    # If the return is empty, encode as None instead of zero
+    #   This is because we don't want to treat missing data as 0 citations
+    if n_citations == 0:
+        citations = None
+    else:
+        citations = [ acite['citing'] for acite in jpage]
+
+    return citations
+
+

--- a/lisc/collect/citations.py
+++ b/lisc/collect/citations.py
@@ -9,7 +9,8 @@ from lisc.urls.open_citations import OpenCitations
 ###################################################################################################
 ###################################################################################################
 
-def collect_citations(dois, util='citations', logging=None, directory=None, verbose=False):
+def collect_citations(dois, util='citations', collect_dois=False,
+                      logging=None, directory=None, verbose=False):
     """Collect citation data from OpenCitations.
 
     Parameters
@@ -30,7 +31,7 @@ def collect_citations(dois, util='citations', logging=None, directory=None, verb
 
     Returns
     -------
-    citations : dict
+    n_citations : dict
         The number of citations for each DOI.
     meta_data : MetaData
         Meta data about the data collection.
@@ -45,15 +46,25 @@ def collect_citations(dois, util='citations', logging=None, directory=None, verb
     if verbose:
         print('Collecting citation data.')
 
-    citations = {doi : get_citation_data(req, urls.get_url(util, [doi])) for doi in dois}
+    n_citations, citing_dois = {}, {}
+    for doi in dois:
+        outputs = get_citation_data(req, urls.get_url(util, [doi]), collect_dois=collect_dois)
+        if collect_dois:
+            n_citations[doi] = outputs[0]
+            citing_dois[doi] = outputs[1]
+        else:
+            n_citations[doi] = outputs
 
     meta_data.add_requester(req)
 
-    return citations, meta_data
+    if not collect_dois:
+        return n_citations, meta_data
+    else:
+        return n_citations, citing_dois, meta_data
 
 
-def get_citation_data(req, citation_url):
-    """Extract the number of citations from an OpenCitations URL request.
+def get_citation_data(req, citation_url, collect_dois=False):
+    """Extract citations from an OpenCitations URL request.
 
     Parameters
     ----------
@@ -66,76 +77,8 @@ def get_citation_data(req, citation_url):
     -------
     n_citations : int
         The number of citations the article has received.
-    """
-
-    page = req.request_url(citation_url)
-    n_citations = len(json.loads(page.content.decode('utf-8')))
-
-    # If the return is empty, encode as None instead of zero
-    #   This is because we don't want to treat missing data as 0 citations
-    if n_citations == 0:
-        n_citations = None
-
-    return n_citations
-
-
-def collect_citation_dois(dois, util='citations', logging=None, directory=None, verbose=False):
-    """Collect a list of DOIs citing the target(s) using OpenCitations.
-
-    Parameters
-    ----------
-    dois : list of str
-        DOIs to collect citation data for.
-    util : {'citations', 'references'}
-        Which utility to collect citation data with. Options:
-
-        * 'citations': collects the number of citations citing the specified DOI.
-        * 'references': collects the number of references cited by the specified DOI.
-    logging : {None, 'print', 'store', 'file'}, optional
-        What kind of logging, if any, to do for requested URLs.
-    directory : str or SCDB, optional
-        Folder or database object specifying the save location.
-    verbose : bool, optional, default: False
-        Whether to print out updates.
-
-    Returns
-    -------
-    citations : dict
-        The number of citations for each DOI.
-    meta_data : MetaData
-        Meta data about the data collection.
-    """
-
-    urls = OpenCitations()
-    urls.build_url(util)
-
-    meta_data = MetaData()
-    req = Requester(wait_time=0.1, logging=logging, directory=directory)
-
-    if verbose:
-        print('Collecting citation data.')
-
-    citations = {doi : get_citation_doi_data(req, urls.get_url(util, [doi])) for doi in dois}
-
-    meta_data.add_requester(req)
-
-    return citations, meta_data
-
-
-def get_citation_doi_data(req, citation_url):
-    """Extract the number of citations from an OpenCitations URL request.
-
-    Parameters
-    ----------
-    req : Requester
-        Requester to launch requests from.
-    citation_url : str
-        URL to collect citation data from.
-
-    Returns
-    -------
-   citations : list of strings
-        The DOIs of articles citing the target article.
+    citing_dois : list of str
+        The DOIs of the citing articles.
     """
 
     page = req.request_url(citation_url)
@@ -145,10 +88,12 @@ def get_citation_doi_data(req, citation_url):
     # If the return is empty, encode as None instead of zero
     #   This is because we don't want to treat missing data as 0 citations
     if n_citations == 0:
-        citations = None
+        n_citations = None
     else:
-        citations = [ acite['citing'] for acite in jpage]
+        if collect_dois:
+            citing_dois = [acite['citing'] for acite in jpage]
 
-    return citations
-
-
+    if not collect_dois:
+        return n_citations
+    else:
+        return n_citations, citing_dois

--- a/lisc/tests/test_collect_citations.py
+++ b/lisc/tests/test_collect_citations.py
@@ -9,8 +9,14 @@ def test_collect_citations():
 
     dois = ['10.1007/s00228-017-2226-2', '10.1186/1756-8722-6-59']
 
-    citations, meta_data = collect_citations(dois, 'citations')
-    assert citations
+    # Test 'citations' collection
+    n_citations, cite_dois, meta_data = collect_citations(dois, 'citations', collect_dois=True)
+    assert len(n_citations) == len(cite_dois) == len(dois)
+    assert isinstance(list(n_citations.values())[0], int)
+    assert isinstance(list(cite_dois.values())[0][0], str)
 
-    references, meta_data = collect_citations(dois, 'references')
-    assert references
+    # Test 'references' collection
+    n_references, ref_dois, meta_data = collect_citations(dois, 'references', collect_dois=True)
+    assert len(n_references) == len(ref_dois) == len(dois)
+    assert isinstance(list(n_references.values())[0], int)
+    assert isinstance(list(ref_dois.values())[0][0], str)


### PR DESCRIPTION
In the end I decided to duplicate the collect_citations() infrastructure with collect_citation_dois(). If you don't like that, it could obviously be melded into a single collect_citations() using an argument about which kind of data to collect. 

Also I have a question about the code in the original: I can't figure out that stuff about 
"# If the return is empty, encode as None instead of zero
  #   This is because we don't want to treat missing data as 0 citations"

I can't see the difference between missing data and 0 citations... what would the json return look like in each case?  I just duped that stuff into my code, but I don't understand it TBH