### PR TITLE
[ENH] - Extend EUtils collections to allow for date related settings

### DIFF
--- a/lisc/collect/counts.py
+++ b/lisc/collect/counts.py
@@ -16,8 +16,8 @@ from lisc.urls.eutils import EUtils, get_wait_time
 
 def collect_counts(terms_a, inclusions_a=None, exclusions_a=None,
                    terms_b=None, inclusions_b=None, exclusions_b=None,
-                   db='pubmed', field='TIAB', api_key=None,
-                   logging=None, directory=None, verbose=False):
+                   db='pubmed', field='TIAB', api_key=None, logging=None,
+                   directory=None, verbose=False, **eutils_kwargs):
     """Collect count and term co-occurrence data from EUtils.
 
     Parameters
@@ -47,6 +47,8 @@ def collect_counts(terms_a, inclusions_a=None, exclusions_a=None,
         Folder or database object specifying the save location.
     verbose : bool, optional, default: False
         Whether to print out updates.
+    **eutils_kwargs
+        Additional settings for the EUtils API.
 
     Returns
     -------
@@ -77,9 +79,10 @@ def collect_counts(terms_a, inclusions_a=None, exclusions_a=None,
     """
 
     # Get e-utils URLS object. Set retmax as 0, since not using UIDs for counts
-    urls = EUtils(db=db, retmax='0', field=field, retmode='xml', api_key=api_key)
+    urls = EUtils(db=db, retmax='0', field=field, retmode='xml', **eutils_kwargs, api_key=api_key)
     urls.build_url('info', settings=['db'])
-    urls.build_url('search', settings=['db', 'retmax', 'retmode', 'field'])
+    search_settings = ['db', 'retmax', 'retmode', 'field']
+    urls.build_url('search', settings=search_settings + list(eutils_kwargs.keys()))
 
     # Initialize meta data & requester
     meta_data = MetaData()

--- a/lisc/collect/words.py
+++ b/lisc/collect/words.py
@@ -15,9 +15,9 @@ from lisc.urls.eutils import EUtils, get_wait_time
 ###################################################################################################
 ###################################################################################################
 
-def collect_words(terms, inclusions=None, exclusions=None, db='pubmed',
-                  retmax=None, field='TIAB', usehistory=False, api_key=None,
-                  save_and_clear=False, logging=None, directory=None, verbose=False):
+def collect_words(terms, inclusions=None, exclusions=None, db='pubmed', retmax=None,
+                  field='TIAB', usehistory=False, api_key=None, save_and_clear=False,
+                  logging=None, directory=None, verbose=False, **eutils_kwargs):
     """Collect text data and metadata from EUtils using specified search term(s).
 
     Parameters
@@ -47,6 +47,8 @@ def collect_words(terms, inclusions=None, exclusions=None, db='pubmed',
         Folder or database object specifying the save location.
     verbose : bool, optional, default: False
         Whether to print out updates.
+    **eutils_kwargs
+        Additional settings for the EUtils API.
 
     Returns
     -------
@@ -71,10 +73,11 @@ def collect_words(terms, inclusions=None, exclusions=None, db='pubmed',
     """
 
     # Get EUtils URLS object, with desired settings, and build required utility URLs
-    urls = EUtils(db=db, usehistory='y' if usehistory else 'n', retmax=retmax,
-                  retmode='xml', field=field, api_key=api_key)
+    urls = EUtils(db=db, retmax=retmax, usehistory='y' if usehistory else 'n',
+                  field=field, retmode='xml', **eutils_kwargs, api_key=api_key)
     urls.build_url('info', settings=['db'])
-    urls.build_url('search', settings=['db', 'usehistory', 'retmax', 'retmode', 'field'])
+    search_settings = ['db', 'usehistory', 'retmax', 'retmode', 'field']
+    urls.build_url('search', settings=search_settings + list(eutils_kwargs.keys()))
     urls.build_url('fetch', settings=['db', 'retmode'])
 
     # Initialize results, meta data & requester

--- a/lisc/objects/counts.py
+++ b/lisc/objects/counts.py
@@ -108,8 +108,8 @@ class Counts():
             self.terms[dim].counts = np.zeros(self.terms[dim].n_terms, dtype=int)
 
 
-    def run_collection(self, db='pubmed', field='TIAB', api_key=None,
-                       logging=None, directory=None, verbose=False):
+    def run_collection(self, db='pubmed', field='TIAB', api_key=None, logging=None,
+                       directory=None, verbose=False, **eutils_kwargs):
         """Collect co-occurrence data.
 
         Parameters
@@ -127,6 +127,8 @@ class Counts():
             Folder or database object specifying the save location.
         verbose : bool, optional, default: False
             Whether to print out updates.
+        **eutils_kwargs
+            Additional settings for the EUtils API.
 
         Examples
         --------
@@ -153,7 +155,7 @@ class Counts():
                 exclusions_a=self.terms['A'].exclusions,
                 db=db, field=field, api_key=api_key,
                 logging=logging, directory=directory,
-                verbose=verbose)
+                verbose=verbose, **eutils_kwargs)
 
         # Run two different sets of terms
         else:
@@ -167,7 +169,7 @@ class Counts():
                 exclusions_b=self.terms['B'].exclusions,
                 db=db, field=field, api_key=api_key,
                 logging=logging, directory=directory,
-                verbose=verbose)
+                verbose=verbose, **eutils_kwargs)
             self.terms['A'].counts, self.terms['B'].counts = term_counts
 
 

--- a/lisc/objects/words.py
+++ b/lisc/objects/words.py
@@ -76,7 +76,7 @@ class Words(Base):
 
     def run_collection(self, db='pubmed', retmax=None, field='TIAB', usehistory=False,
                        api_key=None, save_and_clear=False, logging=None,
-                       directory=None, verbose=False):
+                       directory=None, verbose=False, **eutils_kwargs):
         """Collect words data.
 
         Parameters
@@ -100,6 +100,8 @@ class Words(Base):
             Folder or database object specifying the save location for any outputs.
         verbose : bool, optional, default: False
             Whether to print out updates.
+        **eutils_kwargs
+            Additional settings for the EUtils API.
 
         Examples
         --------
@@ -111,7 +113,6 @@ class Words(Base):
         """
 
         self.results, self.meta_data = collect_words(self.terms, self.inclusions, self.exclusions,
-                                                     db=db, retmax=retmax, field=field,
-                                                     usehistory=usehistory, api_key=api_key,
-                                                     save_and_clear=save_and_clear, logging=logging,
-                                                     directory=directory, verbose=verbose)
+                                                     db=db, retmax=retmax, field=field, usehistory=usehistory,
+                                                     api_key=api_key, save_and_clear=save_and_clear, logging=logging,
+                                                     directory=directory, verbose=verbose, **eutils_kwargs)

--- a/lisc/tests/urls/test_utils.py
+++ b/lisc/tests/urls/test_utils.py
@@ -5,6 +5,21 @@ from lisc.urls.utils import *
 ###################################################################################################
 ###################################################################################################
 
+def test_check_none():
+
+    out1 = check_none(None, 1)
+    assert out1 == 1
+
+    out2 = check_none(1, 2)
+    assert out2 == 1
+
+def test_check_settings():
+
+    settings = {'key1' : 'value1', 'key2' : 12}
+    output = check_settings(settings)
+    for val in output.values():
+        assert isinstance(val, str)
+
 def test_prepend():
 
     assert prepend('Test', '?') == '?Test'

--- a/lisc/urls/eutils.py
+++ b/lisc/urls/eutils.py
@@ -6,6 +6,8 @@ EUtils Quick Start:
     https://www.ncbi.nlm.nih.gov/books/NBK25500/
 EUtils in Depth:
     https://www.ncbi.nlm.nih.gov/books/NBK25499/
+A quick description of E-utilies
+    https://dataguide.nlm.nih.gov/eutilities/utilities.html
 Usage Policies and Disclaimers:
     https://www.ncbi.nlm.nih.gov/home/about/policies/
 A list of all the valid databases:
@@ -26,15 +28,22 @@ Settings
 --------
 db : the target database.
     Most relevant database are: 'pubmed' & 'pmc'
-        - pubmed: is a database of over 25 million references
-        - pmc: an archive of freely available full text articles
+        - pubmed: is a database of biomedical literature
+        - pmc: is a database openly available full text articles
     More info here: https://www.nlm.nih.gov/bsd/difference.html
     FAQ on PMC: https://www.ncbi.nlm.nih.gov/pmc/about/faq/
 id : list of UIDs (comma separated).
 field : the search field to search within.
+    Options include: 'TIAB' (title & abstract), 'TW' (text words), 'ALL', etc
 retmax : maximum number of records to return.
 retmode : format to return.
-usehistory : whether to store findings on remote server.
+    Options include: xml, json
+usehistory : whether to store findings on remote server, as {'y', 'n'}.
+reldate : returns results from the last 'n' days.
+mindate, maxdate : date range to limit results to. Both are required to specify a range.
+    Can be set as YYYY or YYYY/MM or YYYY/MM/DD
+datetype : the type of date to use.
+    Options include: 'pdat' (publication date) and 'edat' (entrez date, when record was added)
 term : search terms to use.
 """
 
@@ -85,7 +94,7 @@ class EUtils(URLs):
     """
 
     def __init__(self, db=None, retmax=None, field=None, retmode=None,
-                 usehistory='n', api_key=None):
+                 usehistory='n', api_key=None, **eutils_kwargs):
         """Initialize the NCBI EUtils URLs, with provided settings.
 
         Parameters
@@ -103,6 +112,8 @@ class EUtils(URLs):
             'n' indicates 'no', do not use history. 'y' indicates 'yes', to use history.
         api_key : str, optional
             An API key for authenticated NCBI user account.
+        **eutils_kwargs
+            Additional settings for the EUtils API.
 
         Examples
         --------
@@ -120,9 +131,13 @@ class EUtils(URLs):
         authenticated = bool(api_key)
         URLs.__init__(self, base, utils, authenticated=authenticated)
 
+        # If there are any date related settings, default to using publication date
+        if 'date' in ''.join(eutils_kwargs.keys()):
+            eutils_kwargs.setdefault('datetype', 'pdat')
+
         # Collect settings, filling in with all defined settings / arguments
-        self.fill_settings(db=db, usehistory=usehistory, retmax=str(retmax),
-                           field=field, retmode=retmode, api_key=api_key)
+        self.fill_settings(db=db, usehistory=usehistory, retmax=retmax, field=field,
+                           retmode=retmode, api_key=api_key, **eutils_kwargs)
 
 
     def authenticate(self, url):

--- a/lisc/urls/urls.py
+++ b/lisc/urls/urls.py
@@ -4,7 +4,7 @@ Segments : section added to the URL, separated by '/'.
 Settings : settings added to the URL, as key value pairs, following a '?' and added with '&'.
 """
 
-from lisc.urls.utils import check_none, make_segments, make_settings
+from lisc.urls.utils import check_none, check_settings, make_segments, make_settings
 
 ###################################################################################################
 ###################################################################################################
@@ -99,7 +99,7 @@ class URLs():
         >>> urls.fill_settings(q='lisc', sort='stars', order='desc')
         """
 
-        self.settings = {ke: va for ke, va in kwargs.items() if va is not None}
+        self.settings = check_settings({ke: va for ke, va in kwargs.items() if va is not None})
 
 
     def authenticate(self, url):

--- a/lisc/urls/utils.py
+++ b/lisc/urls/utils.py
@@ -27,6 +27,23 @@ def check_none(val, default):
     return val if val else default
 
 
+def check_settings(settings):
+    """Check that all settings are defined as strings.
+
+    Parameters
+    ----------
+    settings : dict
+        Dictionary to check.
+
+    Returns
+    -------
+    dict
+        Dictionary with all values set as strings.
+    """
+
+    return {key : str(val) for key, val in settings.items()}
+
+
 def prepend(string, prefix):
     """Append something to the beginning of another string.
 


### PR DESCRIPTION
Responds to #37. Extends EUtils API usage to allow for adding additional settings. This allows for supplying settings related to restricting by date. 