### PR TITLE
[ENH] - Add option to collect counts without co-occurences

### DIFF
--- a/lisc/tests/collect/test_counts.py
+++ b/lisc/tests/collect/test_counts.py
@@ -25,6 +25,6 @@ def test_collect_counts():
     assert meta_data.requester['n_requests'] > 0
 
     # Test coounts without co-occurence
-	counts, meta_data = collect_counts(terms_a, exclusions_a=excls_a, terms_b=terms_b)
-	assert len(counts) == len(terms_a)
-	assert meta_data.requester['n_requests'] > 0
+    counts, meta_data = collect_counts(terms_a, exclusions_a=excls_a, terms_b=terms_b)
+    assert len(counts) == len(terms_a)
+    assert meta_data.requester['n_requests'] > 0

--- a/lisc/tests/collect/test_counts.py
+++ b/lisc/tests/collect/test_counts.py
@@ -11,12 +11,20 @@ def test_collect_counts():
     excls_a = [['protein'], ['protein']]
     terms_b = ['brain']
 
-    n_a = len(terms_a)
-    n_b = len(terms_b)
-
+    # Test co-occurence with two terms lists
     cooc, counts, meta_data = collect_counts(terms_a, exclusions_a=excls_a, terms_b=terms_b)
+    assert cooc.shape == (len(terms_a), len(terms_b))
+    assert len(counts[0]) == len(terms_a)
+    assert len(counts[1]) == len(terms_b)
+    assert meta_data.requester['n_requests'] > 0
 
-    assert cooc.shape == (n_a, n_b)
+    # Test co-occurence with one list of terms
+    cooc, counts, meta_data = collect_counts(terms_a, exclusions_a=excls_a)
+    assert cooc.shape == (len(terms_a), len(terms_a))
+    assert len(counts) == len(terms_a)
+    assert meta_data.requester['n_requests'] > 0
 
-    assert len(counts[0]) == n_a
-    assert len(counts[1]) == n_b
+    # Test coounts without co-occurence
+	counts, meta_data = collect_counts(terms_a, exclusions_a=excls_a, terms_b=terms_b)
+	assert len(counts) == len(terms_a)
+	assert meta_data.requester['n_requests'] > 0


### PR DESCRIPTION
This update allows for using counts collection to collect the number of articles per search term, without doing any co-occurrences. 