### PR TITLE
Update LISC

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -140,8 +140,8 @@ Analysis Functions
 
 Functions to analyze collected data.
 
-Co-Occurence Data
-~~~~~~~~~~~~~~~~~
+Co-Occurrence Data
+~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: lisc.analysis.counts
 
@@ -162,6 +162,7 @@ Words Data
 
     get_all_values
     get_all_counts
+    get_attribute_counts
 
 Plotting Functions
 ------------------

--- a/examples/plot_functions_words.py
+++ b/examples/plot_functions_words.py
@@ -31,7 +31,7 @@ terms = [['brain'], ['body']]
 ###################################################################################################
 
 # Collect words data, setting to collect data for at most 5 articles per term
-results, meta_data = collect_words(terms, retmax='5', usehistory=False,
+results, meta_data = collect_words(terms, retmax=5, usehistory=False,
                                    save_and_clear=False, verbose=True)
 
 ###################################################################################################

--- a/lisc/analysis/words.py
+++ b/lisc/analysis/words.py
@@ -1,5 +1,7 @@
 """Analysis functions for words data."""
 
+from lisc import Words
+
 ###################################################################################################
 ###################################################################################################
 
@@ -53,18 +55,21 @@ def get_all_counts(data, attribute, combine=False):
 
     Parameters
     ----------
-    data : list of ArticlesAll
-        A list of data objects to extract data from.
+    data : words or list of ArticlesAll
+        Article data to extract counts for an attribute of interest.
     attribute : str
-        The attribute to extract from the data objects.
+        The attribute to extract from the data.
     combine : bool, optional, default: False
-    	Whether to combine the counts.
+    	Whether to combine the counts across all search terms.
 
     Returns
     -------
     counts : list
         Extracted counts from across all the data objects.
     """
+
+    if isinstance(data, Words):
+        data = data.combined_results
 
     counts = [getattr(datum, attribute) for datum in data]
 

--- a/lisc/analysis/words.py
+++ b/lisc/analysis/words.py
@@ -3,13 +3,32 @@
 ###################################################################################################
 ###################################################################################################
 
-def get_all_values(all_data, attribute, unique=False):
+def get_attribute_counts(words, attribute):
+    """Get count of how many articles contain values for a requested attribute.
+
+    Parameters
+    ----------
+    words : Words or list of Articles
+        Literature data.
+    attribute : str
+        Which attribute to check.
+
+    Returns
+    -------
+    int
+        The number of articles across the object that have the requested attribute.
+    """
+
+    return sum([1 if values else 0 for comp in words for values in getattr(comp, attribute)])
+
+
+def get_all_values(data, attribute, unique=False):
     """Get all values for a field of interest.
 
     Parameters
     ----------
-    all_data : list of lisc.ArticlesAll
-        A list of data objects to extract data from.
+    data : Words or list of Articles
+        Data to extract attribute of interest from.
     attribute : str
         The attribute to extract from the data objects.
     unique : bool, optional, default: False
@@ -21,7 +40,7 @@ def get_all_values(all_data, attribute, unique=False):
         Extracted values from across all the data objects.
     """
 
-    values = [val for attrs in [getattr(data, attribute) for data in all_data] for val in attrs]
+    values = [values for component in data for values in getattr(component, attribute)]
 
     if unique:
         values = list(set(values))
@@ -29,12 +48,12 @@ def get_all_values(all_data, attribute, unique=False):
     return values
 
 
-def get_all_counts(all_data, attribute, combine=False):
+def get_all_counts(data, attribute, combine=False):
     """Get all counts for a field of interest.
 
     Parameters
     ----------
-    all_data : list of lisc.ArticlesAll
+    data : list of ArticlesAll
         A list of data objects to extract data from.
     attribute : str
         The attribute to extract from the data objects.
@@ -47,7 +66,7 @@ def get_all_counts(all_data, attribute, combine=False):
         Extracted counts from across all the data objects.
     """
 
-    counts = [getattr(data, attribute) for data in all_data]
+    counts = [getattr(datum, attribute) for datum in data]
 
     if combine:
         counts = sum(counts, type(counts[0])())

--- a/lisc/collect/words.py
+++ b/lisc/collect/words.py
@@ -139,10 +139,15 @@ def collect_words(terms, inclusions=None, exclusions=None, labels=None,
             web_env = page_soup.find('webenv').text
             query_key = page_soup.find('querykey').text
 
-            # Loop through, collecting 100 articles at a time, using history
-            retmax_it = 100
+            # Set default retmax per history iteration
+            retmax_hist = 100
+
+            # Loop through, using history to collect groups of articles at a time
             retstart_it = 0
             while retstart_it < count:
+
+                # Set the retmax for the current iteration
+                retmax_it = min(retmax-retstart_it, retmax_hist)
 
                 # Get article page, collect data
                 url_settings = {'WebEnv' : web_env, 'query_key' : query_key,
@@ -151,7 +156,7 @@ def collect_words(terms, inclusions=None, exclusions=None, labels=None,
                 arts = get_articles(req, art_url, arts)
 
                 # Update position for counting, and break out if more than global retmax
-                retstart_it += retmax_it
+                retstart_it += retmax_hist
                 if retstart_it >= int(retmax):
                     break
 

--- a/lisc/core/errors.py
+++ b/lisc/core/errors.py
@@ -3,6 +3,8 @@
 ###################################################################################################
 ###################################################################################################
 
-class InconsistentDataError(Exception):
+class LISCError(Exception):
+    """Base class for errors in the LISC module."""
+
+class InconsistentDataError(LISCError):
     """Custom error for when data is inconsistent."""
-    pass

--- a/lisc/data/articles.py
+++ b/lisc/data/articles.py
@@ -4,9 +4,10 @@ import os
 import json
 
 from lisc.data.term import Term
-from lisc.utils.db import check_directory
+from lisc.data.process import process_articles
 from lisc.data.base_articles import BaseArticles
 from lisc.core.errors import InconsistentDataError
+from lisc.utils.db import check_directory
 from lisc.utils.io import parse_json_data, check_ext
 
 ###################################################################################################
@@ -21,10 +22,12 @@ class Articles(BaseArticles):
         Label for the term.
     term : Term
         Definition of the search term, with inclusion and exclusion words.
-    ids : list of int
-        Article ids for all articles.
+    has_data : bool
+        Whether the object contains data.
     n_articles : int
         Number of articles collected.
+    ids : list of int
+        Article ids for all articles.
     titles : list of str
         Titles of all articles.
     journals : list of tuple of (str, str)
@@ -39,6 +42,8 @@ class Articles(BaseArticles):
         Publication year of each article.
     dois : list of str
         DOIs of each article.
+    processed : bool
+        Whether the article data has been processed.
     """
 
     def __init__(self, term):
@@ -58,6 +63,7 @@ class Articles(BaseArticles):
 
         # Inherit from the BaseArticles object
         BaseArticles.__init__(self, term)
+        self.processed = False
 
 
     def __getitem__(self, ind):
@@ -194,6 +200,23 @@ class Articles(BaseArticles):
 
         self.save(directory)
         self.clear()
+
+
+    def process(self, process_func=None):
+        """Process the data stored in the current object.
+
+        Parameters
+        ----------
+        process_func : callable, optional
+            A function to process the articles. Must take as input an `Articles` object.
+            If not provided, applies the default `process_articles` function.
+        """
+
+        if not process_func:
+            process_func = process_articles
+
+        process_func(self)
+        self.processed = True
 
 
     def _check_results(self):

--- a/lisc/data/articles.py
+++ b/lisc/data/articles.py
@@ -51,7 +51,7 @@ class Articles(BaseArticles):
 
         Examples
         --------
-        Intialize an ``Articles`` object, with a label for the search term it represents:
+        Initialize an ``Articles`` object, with a label for the search term it represents:
 
         >>> articles = Articles('frontal lobe')
         """
@@ -60,13 +60,13 @@ class Articles(BaseArticles):
         BaseArticles.__init__(self, term)
 
 
-    def __iter__(self):
-        """Iterate through collected articles."""
+    def __getitem__(self, ind):
+        """Index into a object, getting a specific article based on it's index."""
 
-        for ind in range(self.n_articles):
+        if len(self) == 0:
+            raise IndexError('No data is available - cannot proceed.')
 
-            yield {
-                'id': self.ids[ind],
+        return {'id': self.ids[ind],
                 'title': self.titles[ind],
                 'journal': self.journals[ind],
                 'authors': self.authors[ind],
@@ -74,6 +74,19 @@ class Articles(BaseArticles):
                 'keywords': self.keywords[ind],
                 'year': self.years[ind],
                 'doi': self.dois[ind]}
+
+
+    def __iter__(self):
+        """Iterate through collected articles."""
+
+        for ind in range(self.n_articles):
+            yield self[ind]
+
+
+    def __len__(self):
+        """Add access to getting length of object as number of articles."""
+
+        return self.n_articles
 
 
     def add_data(self, field, new_data):
@@ -148,15 +161,15 @@ class Articles(BaseArticles):
 
         self.term = Term(*next(data)['term'])
 
-        for dat in data:
-            self.add_data('ids', dat['id'])
-            self.add_data('titles', dat['title'])
-            self.add_data('journals', dat['journal'])
-            self.add_data('authors', dat['authors'])
-            self.add_data('words', dat['words'])
-            self.add_data('keywords', dat['keywords'])
-            self.add_data('years', dat['year'])
-            self.add_data('dois', dat['doi'])
+        for datum in data:
+            self.add_data('ids', datum['id'])
+            self.add_data('titles', datum['title'])
+            self.add_data('journals', datum['journal'])
+            self.add_data('authors', datum['authors'])
+            self.add_data('words', datum['words'])
+            self.add_data('keywords', datum['keywords'])
+            self.add_data('years', datum['year'])
+            self.add_data('dois', datum['doi'])
 
         self._check_results()
 

--- a/lisc/data/articles_all.py
+++ b/lisc/data/articles_all.py
@@ -22,6 +22,8 @@ class ArticlesAll(BaseArticles):
         Label for the term.
     term : Term
         Definition of the search term, with inclusion and exclusion words.
+    has_data : bool
+        Whether the object contains data.
     n_articles : int
         Number of articles included in object.
     ids : list of int
@@ -69,7 +71,8 @@ class ArticlesAll(BaseArticles):
         BaseArticles.__init__(self, articles.term)
 
         # Process the article data
-        articles = process_articles(articles)
+        if not articles.processed:
+            articles = process_articles(articles)
 
         # Set exclusions, copying input list, if given, and adding current search terms
         exclusions = list(set((deepcopy(exclusions) if exclusions else []) + \

--- a/lisc/data/articles_all.py
+++ b/lisc/data/articles_all.py
@@ -6,8 +6,9 @@ from copy import deepcopy
 
 from lisc.utils.io import check_ext
 from lisc.utils.db import check_directory
-from lisc.data.utils import combine_lists, convert_string, count_elements, drop_none
+from lisc.data.utils import combine_lists, count_elements, drop_none
 from lisc.data.base_articles import BaseArticles
+from lisc.data.process import process_articles
 
 ###################################################################################################
 ###################################################################################################
@@ -45,12 +46,12 @@ class ArticlesAll(BaseArticles):
         A summary of the data associated with the current object.
     """
 
-    def __init__(self, term_data, exclusions=None):
+    def __init__(self, articles, exclusions=None):
         """Initialize ArticlesAll object.
 
         Parameters
         ----------
-        term_data : Articles
+        articles : Articles
             Data for all articles from a given search term.
         exclusions : list of str, optional
             Words to exclude from the word collections.
@@ -65,26 +66,31 @@ class ArticlesAll(BaseArticles):
         """
 
         # Inherit from the BaseArticles object
-        BaseArticles.__init__(self, term_data.term)
+        BaseArticles.__init__(self, articles.term)
+
+        # Process the article data
+        articles = process_articles(articles)
 
         # Set exclusions, copying input list, if given, and adding current search terms
         exclusions = list(set((deepcopy(exclusions) if exclusions else []) + \
-            [term_data.term.label] + term_data.term.search + term_data.term.inclusions))
+            [articles.term.label] + articles.term.search + articles.term.inclusions))
 
         # Copy over tracking of included IDs & DOIs
-        self.ids = term_data.ids
-        self.dois = term_data.dois
+        self.ids = articles.ids
+        self.dois = articles.dois
 
-        # Get frequency distributions of authors, journals, years
-        self.journals = count_elements([journal[0] for journal in term_data.journals])
-        self.years = count_elements(term_data.years)
-        self.authors = _count_authors(term_data.authors)
-        self.first_authors, self.last_authors = _count_end_authors(term_data.authors)
+        # Get frequency distributions of years, journals, authors
+        self.years = count_elements(articles.years)
+        self.journals = count_elements(articles.journals)
+        self.first_authors = count_elements(\
+            auth[0] if auth else None for auth in articles.authors)
+        self.last_authors = count_elements(\
+            auth[-1] if auth and len(auth) > 1 else None for auth in articles.authors)
+        self.authors = count_elements(combine_lists(articles.authors))
 
         # Convert lists of all words to frequency distributions
-        temp_words = [convert_string(words) for words in term_data.words]
-        self.words = count_elements(combine_lists(temp_words), exclusions)
-        self.keywords = count_elements(combine_lists(term_data.keywords), exclusions)
+        self.words = count_elements(combine_lists(articles.words), exclusions)
+        self.keywords = count_elements(combine_lists(articles.keywords), exclusions)
 
         # Initialize summary dictionary
         self.summary = dict()
@@ -187,85 +193,3 @@ class ArticlesAll(BaseArticles):
 
         with open(os.path.join(directory, check_ext(self.label, '.json')), 'w') as outfile:
             json.dump(self.summary, outfile)
-
-
-def _count_authors(authors):
-    """Count all authors.
-
-    Parameters
-    ----------
-    authors : list of list of tuple of (str, str, str, str)
-        Authors, as (last name, first name, initials, affiliation).
-
-    Returns
-    -------
-    author_counts : collections.Counter
-        Number of publications per author.
-    """
-
-    # Reduce author fields to pair of tuples (last name, initials)
-    all_authors = [(author[0], author[2]) for art_authors \
-        in drop_none(authors) for author in art_authors]
-
-    # Standardize author names and count number of publications per author
-    author_counts = count_elements(_fix_author_names(all_authors))
-
-    return author_counts
-
-
-def _count_end_authors(authors):
-    """Count first and last authors only.
-
-    Parameters
-    ----------
-    authors : list of list of tuple of (str, str, str, str)
-        Authors, as (last name, first name, initials, affiliation).
-
-    Returns
-    -------
-    first_counts, last_counts : collections.Counter
-        Number of publications for each first and last author.
-    """
-
-    # Pull out the full name for the first & last author of each article
-    #  Last author is only considered if there is more than 1 author
-    firsts = [auth[0] for auth in drop_none(authors)]
-    f_names = [(author[0], author[2]) for author in firsts]
-
-    lasts = [auth[-1] for auth in drop_none(authors) if len(auth) > 1]
-    l_names = [(author[0], author[2]) for author in lasts]
-
-    f_counts = count_elements(_fix_author_names(f_names))
-    l_counts = count_elements(_fix_author_names(l_names))
-
-    return f_counts, l_counts
-
-
-def _fix_author_names(names):
-    """Fix author names.
-
-    Parameters
-    ----------
-    names : list of tuple of (str, str)
-        Author names, as (last name, initials).
-
-    Returns
-    -------
-    names : list of tuple of (str, str)
-        Author names, as (last name, initials).
-
-    Notes
-    -----
-    Sometimes full author name ends up in the last name field.
-    If first name is None, assume this happened:
-    Split up the text in first name, and grab the first name initial.
-    """
-
-    # Drop names where the contents is all None
-    names = [name for name in names if name != (None, None)]
-
-    # Fix names if full name ended up in last name field
-    names = [(name[0].split(' ')[-1], ''.join([temp[0] for temp in name[0].split(' ')[:-1]]))
-             if name[1] is None else name for name in names]
-
-    return names

--- a/lisc/data/base_articles.py
+++ b/lisc/data/base_articles.py
@@ -20,8 +20,14 @@ class BaseArticles():
         # If term provided is a string, consider it the label and make a Term object
         if isinstance(term, str):
             term = Term(term, [], [], [])
-
         self.term = term
+
+        # Initialize the data attributes
+        self._initialize_attributes()
+
+
+    def _initialize_attributes(self):
+        """Initialize the data attributes of the object."""
 
         self.ids = list()
         self.titles = list()
@@ -50,11 +56,5 @@ class BaseArticles():
     def clear(self):
         """Clear all data attached to object."""
 
-        self.ids = list()
-        self.titles = list()
-        self.journals = list()
-        self.authors = list()
-        self.words = list()
-        self.keywords = list()
-        self.years = list()
-        self.dois = list()
+        # Clear attributes by re-initializing to empty
+        self._initialize_attributes()

--- a/lisc/data/base_articles.py
+++ b/lisc/data/base_articles.py
@@ -47,6 +47,13 @@ class BaseArticles():
 
 
     @property
+    def has_data(self):
+        """Whether the current object contains data."""
+
+        return bool(self.n_articles)
+
+
+    @property
     def n_articles(self):
         """The number of articles included in the object."""
 

--- a/lisc/data/process.py
+++ b/lisc/data/process.py
@@ -1,0 +1,85 @@
+"""Utilities for processing article data."""
+
+from lisc.data.utils import convert_string, lower_list
+
+###################################################################################################
+###################################################################################################
+
+def process_articles(articles):
+    """Process collected data in an Articles object.
+
+    Parameters
+    ----------
+    articles : Articles
+        Articles data.
+
+    Notes
+    -----
+    Processing includes tokenizing the text data and preprocessing the journal and author names.
+    """
+
+    # Process text data: tokenizing, dropping stopwords, and making lowercase
+    articles.words = [convert_string(words) for words in articles.words]
+    articles.keywords = [lower_list(keywords) for keywords in articles.keywords]
+
+    # Sub-select the journal names, keeping only the
+    articles.journals = [journal[0] for journal in articles.journals]
+
+    # Process author data: restrict the last name and initials
+    articles.authors = _process_authors(articles.authors)
+
+    return articles
+
+
+def _process_authors(authors):
+    """Process author names.
+
+    Parameters
+    ----------
+    authors : list of list of str
+        Collected author information. Each list is an articles.
+        Each author is [last_name, first_name, initials, affiliations]
+
+    Notes
+    -----
+    Processing means checking the author names and dropping to [last_name, initials].
+    """
+
+    # Reduce author fields to pair of tuples (last name, initials)
+    authors = [[(author[0], author[2]) for author in art_authors] if art_authors else None \
+        for art_authors in authors]
+
+    # Check and fix author names
+    authors = [_fix_author_names(art_authors) if art_authors else None for art_authors in authors]
+
+    return authors
+
+
+def _fix_author_names(names):
+    """Fix author names.
+
+    Parameters
+    ----------
+    names : list of tuple of (str, str)
+        Author names, as (last name, initials).
+
+    Returns
+    -------
+    names : list of tuple of (str, str)
+        Author names, as (last name, initials).
+
+    Notes
+    -----
+    Sometimes full author name ends up in the last name field.
+    If first name is None, assume this happened:
+    Split up the text in first name, and grab the first name initial.
+    """
+
+    # Drop names where the contents is all None
+    names = [name for name in names if name != (None, None)]
+
+    # Fix names if full name ended up in last name field
+    names = [(name[0].split(' ')[-1], ''.join([temp[0] for temp in name[0].split(' ')[:-1]]))
+             if name[1] is None else name for name in names]
+
+    return names

--- a/lisc/data/process.py
+++ b/lisc/data/process.py
@@ -1,22 +1,29 @@
 """Utilities for processing article data."""
 
+from copy import deepcopy
+
 from lisc.data.utils import convert_string, lower_list
 
 ###################################################################################################
 ###################################################################################################
 
-def process_articles(articles):
+def process_articles(articles, process_copy=False):
     """Process collected data in an Articles object.
 
     Parameters
     ----------
     articles : Articles
         Articles data.
+    process_copy : bool, optional, default: False
+        Whether to process a copy of the input.
 
     Notes
     -----
     Processing includes tokenizing the text data and preprocessing the journal and author names.
     """
+
+    if process_copy:
+        articles = deepcopy(articles)
 
     # Process text data: tokenizing, dropping stopwords, and making lowercase
     articles.words = [convert_string(words) for words in articles.words]

--- a/lisc/data/utils.py
+++ b/lisc/data/utils.py
@@ -1,5 +1,6 @@
 """Utilities for data management and data object for LISC."""
 
+from itertools import chain
 from string import punctuation
 from collections import Counter
 
@@ -15,7 +16,7 @@ def count_elements(lst, exclude=None):
     ----------
     lst : list
         List of items to count.
-    exclude : list
+    exclude : list, optional
         Items to exclude from the frequency distribution.
 
     Returns
@@ -26,11 +27,13 @@ def count_elements(lst, exclude=None):
 
     counts = Counter(lst)
 
+    # Drop the value for None
     try:
         counts.pop(None)
     except KeyError:
         pass
 
+    # Drop any items set as exclusions
     if exclude:
 
         if isinstance(exclude[0], str):
@@ -83,31 +86,21 @@ def drop_none(lst):
             yield el
 
 
-def combine_lists(in_lst):
+def combine_lists(lst):
     """Combine list of lists into one large list.
 
     Parameters
     ----------
-    in_lst : list of list of str
+    lst : list of list
         Embedded lists to combine.
 
     Returns
     -------
-    out : list of str
-        Combined list.
-
-    Notes
-    -----
-    This function also converts all contained strings to lowercase.
+    out : list
+        Combined (flat) list.
     """
 
-    out = []
-
-    for el in in_lst:
-        if el:
-            out.extend(lower_list(el))
-
-    return out
+    return list(chain.from_iterable(drop_none(lst)))
 
 
 def tokenize(text):
@@ -162,7 +155,7 @@ def convert_string(text, stopwords=STOPWORDS):
     This function sets text to lower case, and removes stopwords and punctuation.
     """
 
-    # Converting to use a dictionaries makes checking a little more efficient
+    # Converting to use a dictionary makes checking a little more efficient
     stopwords = Counter(stopwords)
 
     # Tokenize and remove stopwords

--- a/lisc/objects/base.py
+++ b/lisc/objects/base.py
@@ -284,8 +284,8 @@ class Base():
 
         Attributes
         ----------
-        term_type : {'terms', 'inclusions', 'exclusions', 'all'}
-            Which type of terms to use.
+        term_type : {'terms', 'inclusions', 'exclusions', 'labels', 'all'}
+            Which type of terms to unload.
         verbose : bool, optional
             Whether to be verbose in printing out any changes.
 
@@ -346,8 +346,8 @@ class Base():
         if self.has_terms and (not self._labels or self._labels == [None] * len(self._labels)):
             self._set_none_labels()
 
-        if not self.n_terms == len(set(self.labels)):
-            raise ValueError('Not all labels are unique. Labels must be unique.')
+        if not len(self.labels) == len(set(self.labels)):
+            raise InconsistentDataError('Not all labels are unique. Labels must be unique.')
 
 
     def _add_term(self, term):

--- a/lisc/objects/base.py
+++ b/lisc/objects/base.py
@@ -346,6 +346,9 @@ class Base():
         if self.has_terms and (not self._labels or self._labels == [None] * len(self._labels)):
             self._set_none_labels()
 
+        if not self.n_terms == len(set(self.labels)):
+            raise ValueError('Not all labels are unique. Labels must be unique.')
+
 
     def _add_term(self, term):
         """Add term information from a Term object.

--- a/lisc/objects/words.py
+++ b/lisc/objects/words.py
@@ -3,6 +3,7 @@
 from lisc.collect import collect_words
 from lisc.objects.base import Base
 from lisc.objects.utils import get_max_length
+from lisc.data.articles_all import ArticlesAll
 
 ###################################################################################################
 ###################################################################################################
@@ -12,10 +13,14 @@ class Words(Base):
 
     Attributes
     ----------
-    results : list of Articles
-        Results of 'Words' data for each search term.
     labels : list of str
         Labels for each data object attached to the object.
+    has_data : bool
+        Whether the object contains data.
+    results : list of Articles
+        Results of 'Words' data collection for each search term.
+    combined_results : list of ArticlesAll
+        Results for each search term combined across individual articles.
     meta_data : MetaData
         Meta data information about the data collection.
     """
@@ -26,6 +31,7 @@ class Words(Base):
         Base.__init__(self)
 
         self.results = list()
+        self.combined_results = list()
         self.meta_data = None
 
 
@@ -157,3 +163,31 @@ class Words(Base):
         for ind in list(reversed(sorted(inds))):
             self.drop_term(ind)
             self.results.pop(ind)
+
+
+    def process_articles(self, process_func=None):
+        """Process the articles stored in the object.
+
+        Parameters
+        ----------
+        process_func : callable, optional
+            A function to process article data. Must take as input an `Articles` object.
+            If not provided, applies the default `process_articles` function.
+        """
+
+        for arts in self.results:
+            arts.process(process_func)
+
+
+    def process_combined_results(self):
+        """Process article data to create combined results, across all articles, for each term.
+
+        Notes
+        -----
+        This function will process the article data contained in the object.
+        """
+
+        if not self.has_data:
+            raise ValueError('Object has no data - cannot proceed.')
+
+        self.combined_results = [ArticlesAll(result) for result in self.results]

--- a/lisc/tests/analysis/test_words.py
+++ b/lisc/tests/analysis/test_words.py
@@ -7,15 +7,32 @@ from lisc.analysis.words import *
 ###################################################################################################
 ###################################################################################################
 
-def test_get_all_values(tarts_all):
+def test_get_attribute_counts(twords_full, tarts_full, tarts_none):
 
-    lst = [tarts_all, tarts_all]
+    attr = 'dois'
 
+    count = get_attribute_counts(twords_full, attr)
+    assert count == sum([len(getattr(res, attr)) for res in twords_full.results])
+
+    count = get_attribute_counts([tarts_full, tarts_full], attr)
+    assert count == len(getattr(tarts_full, attr)) * 2
+
+    count = get_attribute_counts([tarts_none, tarts_none], attr)
+    assert count == len(getattr(tarts_none, attr)) * 2 - 2
+
+
+def test_get_all_values(twords_full, tarts_full, tarts_none):
+
+    attr = 'dois'
+
+    values = get_all_values(twords_full, attr)
+
+    lst = [tarts_full, tarts_full]
     vals = get_all_values(lst, 'dois')
-    assert len(vals) == 2*len(tarts_all.dois)
+    assert len(vals) == 2 * len(tarts_full.dois)
 
     vals = get_all_values(lst, 'dois', unique=True)
-    assert len(vals) == len(set(tarts_all.dois))
+    assert len(vals) == len(set(tarts_full.dois))
 
 def test_get_all_counts(tarts_all):
 

--- a/lisc/tests/analysis/test_words.py
+++ b/lisc/tests/analysis/test_words.py
@@ -34,16 +34,23 @@ def test_get_all_values(twords_full, tarts_full, tarts_none):
     vals = get_all_values(lst, 'dois', unique=True)
     assert len(vals) == len(set(tarts_full.dois))
 
-def test_get_all_counts(tarts_all):
+def test_get_all_counts(twords_full, tarts_all):
 
+    attr = 'words'
+
+    ## Test ArticlesAll input
     lst = [tarts_all, tarts_all]
 
     # Test for non-combined outputs
-    counts = get_all_counts(lst, 'words')
+    counts = get_all_counts(lst, attr)
     assert isinstance(counts, list)
     assert len(counts) == len(lst)
 
     # Test for combined output
-    counts = get_all_counts(lst, 'words', combine=True)
+    counts = get_all_counts(lst, attr, combine=True)
     assert isinstance(counts, Counter)
     assert len(counts) == len(tarts_all.words)
+
+    ## Test words input
+    counts = get_all_counts(twords_full, attr)
+    assert isinstance(counts, list)

--- a/lisc/tests/conftest.py
+++ b/lisc/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 import os
 import shutil
+from copy import deepcopy
 import pkg_resources as pkg
 
 from lisc.objects import Counts, Words
@@ -59,12 +60,12 @@ def tcounts():
 def twords():
     return Words()
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def twords_full():
 
     words = Words()
     arts = load_arts(add_data=True, n_data=2)
-    words.results = [arts, arts]
+    words.results = [arts, deepcopy(arts)]
 
     return words
 

--- a/lisc/tests/conftest.py
+++ b/lisc/tests/conftest.py
@@ -59,6 +59,15 @@ def tcounts():
 def twords():
     return Words()
 
+@pytest.fixture(scope='session')
+def twords_full():
+
+    words = Words()
+    arts = load_arts(add_data=True, n_data=2)
+    words.results = [arts, arts]
+
+    return words
+
 @pytest.fixture(scope='function')
 def treq():
     return Requester()
@@ -78,6 +87,10 @@ def tarts_empty():
 @pytest.fixture(scope='function')
 def tarts_full():
     return load_arts(add_data=True, n_data=2)
+
+@pytest.fixture(scope='function')
+def tarts_none():
+    return load_arts(add_data=True, n_data=2, add_none=True)
 
 @pytest.fixture(scope='function')
 def tarts_all():

--- a/lisc/tests/data/test_articles.py
+++ b/lisc/tests/data/test_articles.py
@@ -83,3 +83,8 @@ def test_save_and_clear(tdb, tarts_full):
 
     tarts_full.save_and_clear(tdb)
     assert tarts_full.n_articles == 0
+
+def test_process(tarts_full):
+
+    tarts_full.process()
+    assert tarts_full.processed

--- a/lisc/tests/data/test_articles.py
+++ b/lisc/tests/data/test_articles.py
@@ -13,12 +13,24 @@ from lisc.data.articles import *
 
 def test_articles():
 
-    assert Articles(Term('label', ['search'], ['inclusion'], ['exclusion']))
+    arts = Articles(Term('label', ['search'], ['inclusion'], ['exclusion']))
+    assert isinstance(arts, Articles)
+
+def test_get_item(tarts_full):
+
+    for ind in range(tarts_full.n_articles):
+        art = tarts_full[ind]
+        assert art
 
 def test_iter(tarts_full):
 
     for data in tarts_full:
         assert data
+
+def test_len(tarts_empty, tarts_full):
+
+    assert len(tarts_empty) == 0
+    assert len(tarts_full) == len(tarts_full.ids)
 
 def test_add_data(tarts_empty):
 

--- a/lisc/tests/data/test_articles_all.py
+++ b/lisc/tests/data/test_articles_all.py
@@ -1,7 +1,6 @@
 """Tests for lisc.data.articles_all."""
 
 from lisc.data.articles_all import *
-from lisc.data.articles_all import _count_authors, _count_end_authors, _fix_author_names
 
 ###################################################################################################
 ###################################################################################################
@@ -9,6 +8,11 @@ from lisc.data.articles_all import _count_authors, _count_end_authors, _fix_auth
 def test_articles_all(tarts_full):
 
     data_all = ArticlesAll(tarts_full)
+    assert data_all
+
+def test_articles_all_none(tarts_none):
+
+    data_all = ArticlesAll(tarts_none)
     assert data_all
 
 def test_check(tarts_all):
@@ -24,35 +28,3 @@ def test_summary(tdb, tarts_all):
 
     tarts_all.print_summary()
     tarts_all.save_summary(directory=tdb)
-
-def test_count_authors():
-
-    tdata = [[('Smith', 'Alfred', 'AS', 'Python'),
-              ('Doe', 'Jane', 'JR', 'JavaScript')],
-             [('Smith', 'Alfred', 'AS', 'Python')]]
-    out = _count_authors(tdata)
-
-    assert out[('Smith', 'AS')] == 2
-    assert out[('Doe', 'JR')] == 1
-
-def test_count_end_authors():
-
-    tdata = [[('Smith', 'Alfred', 'AS', 'Python'),
-              ('Middle', 'Arthur', 'AA', 'Matlab'),
-              ('Doe', 'Jane', 'JR', 'JavaScript')],
-             [('Smith', 'Alfred', 'AS', 'Python')]]
-
-    f_authors, l_authors = _count_end_authors(tdata)
-
-    assert f_authors[('Smith', 'AS')] == 2
-    assert l_authors[('Doe', 'JR')] == 1
-
-def test_fix_author_names():
-
-    tdata = [('Smith', 'AS'), (None, None), ('Doe', 'JR'), ('First Middle Last', None)]
-    out = _fix_author_names(tdata)
-
-    assert out[0] == ('Smith', 'AS')
-    assert out[1] == ('Doe', 'JR')
-    assert None not in out
-    assert out[-1] == ('Last', 'FM')

--- a/lisc/tests/data/test_process.py
+++ b/lisc/tests/data/test_process.py
@@ -1,0 +1,51 @@
+"""Tests for lisc.data.process."""
+
+from lisc.data.process import *
+from lisc.data.process import _process_authors, _fix_author_names
+
+###################################################################################################
+###################################################################################################
+
+def test_process_articles(tarts_full):
+
+    arts = process_articles(tarts_full)
+
+    # Check that data attributes maintain expected size
+    for attr in ['words', 'years', 'authors', 'journals']:
+        assert len(getattr(arts, attr)) == tarts_full.n_articles
+
+    # Check that the processed attributes have correct types
+    assert len(arts.authors[0]) == 2
+    assert isinstance(arts.authors[0], list)
+    assert isinstance(arts.authors[0][0], tuple)
+    assert isinstance(arts.journals[0], str)
+    assert isinstance(arts.words[0], list)
+
+def test_process_with_none(tarts_none):
+
+    arts = process_articles(tarts_none)
+    for attr in ['words', 'years', 'authors', 'journals']:
+        assert len(getattr(arts, attr)) == tarts_none.n_articles
+
+def test_process_authors():
+
+    tauthors = [[('Smith', 'Alfred', 'AS', 'Python'),
+                 ('Doe', 'Jane', 'JR', 'JavaScript')],
+                [('Smith', 'Alfred', 'AS', 'Python')]]
+    out = _process_authors(tauthors)
+
+    for ind in range(len(out)):
+        assert len(out[ind]) == len(tauthors[ind])
+
+    assert out[0] == [('Smith', 'AS'), ('Doe', 'JR')]
+    assert out[1] == [('Smith', 'AS')]
+
+def test_fix_author_names():
+
+    tdata = [('Smith', 'AS'), (None, None), ('Doe', 'JR'), ('First Middle Last', None)]
+    out = _fix_author_names(tdata)
+
+    assert out[0] == ('Smith', 'AS')
+    assert out[1] == ('Doe', 'JR')
+    assert None not in out
+    assert out[-1] == ('Last', 'FM')

--- a/lisc/tests/objects/test_base.py
+++ b/lisc/tests/objects/test_base.py
@@ -103,13 +103,19 @@ def test_add_terms_term(tbase, tterm):
     assert tbase.inclusions[0] == tterm.inclusions
     assert tbase.exclusions[0] == tterm.exclusions
 
-    terms = [tterm, tterm]
+    # Test with 2 terms. Note second term needs a unique label
+    tterm2 = Term(label='label2', search=['test2', 'synonym2'],
+                  inclusions=['incl2', 'incl_synonym2'],
+                  exclusions=['excl2', 'excl_synonym2'])
+
+    terms = [tterm, tterm2]
     tbase.add_terms(terms)
     assert tbase.n_terms == len(terms)
-    assert tbase.labels[1] == tterm.label
-    assert tbase.terms[1] == tterm.search
-    assert tbase.inclusions[1] == tterm.inclusions
-    assert tbase.exclusions[1] == tterm.exclusions
+    for ind, term in enumerate(terms):
+        assert tbase.labels[ind] == terms[ind].label
+        assert tbase.terms[ind] == terms[ind].search
+        assert tbase.inclusions[ind] == terms[ind].inclusions
+        assert tbase.exclusions[ind] == terms[ind].exclusions
 
 def test_add_terms_file(tdb, tbase):
 
@@ -126,8 +132,11 @@ def test_add_terms_file(tdb, tbase):
 
 def test_add_labels(tbase):
 
-    # Test explicitly added labels, alone
+    # Define test terms & labels
     labels = ['first', 'second']
+    terms = ['word', 'thing']
+
+    # Test explicitly added labels, alone
     tbase.add_labels(labels, check_consistency=False)
     assert tbase.labels == tbase._labels == labels
 
@@ -135,7 +144,6 @@ def test_add_labels(tbase):
     tbase.unload_terms('all', False)
 
     # Test explicitly added labels, when terms are present
-    terms = ['word', 'thing']
     tbase.add_terms(terms)
     tbase.add_labels(labels)
     assert tbase.labels == tbase._labels == labels
@@ -229,3 +237,8 @@ def test_check_labels(tbase, tbase_terms):
 
     tbase_terms._labels = ['label1', 'label2']
     tbase_terms._check_labels()
+
+    # Test error with non-unique labels
+    with raises(InconsistentDataError):
+        tbase_terms._labels = ['label', 'label']
+        tbase_terms._check_labels()

--- a/lisc/tests/objects/test_words.py
+++ b/lisc/tests/objects/test_words.py
@@ -27,7 +27,8 @@ def test_get_item(tterm):
         words['wrong']
 
     # Test properly extracting item
-    assert words[tterm.label]
+    arts = words[tterm.label]
+    assert isinstance(arts, Articles)
 
 def test_add_results(tterm):
 

--- a/lisc/tests/objects/test_words.py
+++ b/lisc/tests/objects/test_words.py
@@ -71,3 +71,15 @@ def drop_data(words, n_articles):
 
     words.drop_data(n_articles)
     assert words.n_terms == len(words.results) == 0
+
+def test_process_articles(twords_full):
+
+    twords_full.process_articles()
+    assert twords_full.results[0].processed
+
+def test_process_combined_results(twords_full):
+
+    twords_full.process_combined_results()
+    assert len(twords_full.results) == len(twords_full.combined_results)
+    assert twords_full.results[0].dois == twords_full.combined_results[0].dois
+    assert twords_full.results[0].authors != twords_full.combined_results[0].authors

--- a/lisc/tests/tobjs.py
+++ b/lisc/tests/tobjs.py
@@ -61,7 +61,7 @@ def load_base(set_terms=False, set_clusions=False, set_labels=False, n_terms=2):
 
     return base
 
-def load_arts(add_data=False, n_data=1):
+def load_arts(add_data=False, n_data=1, add_none=False):
     """Helper function to load Articles object for testing."""
 
     arts = Articles(Term('label', ['search'], ['inclusion'], ['exclusion']))
@@ -69,14 +69,21 @@ def load_arts(add_data=False, n_data=1):
     if add_data:
         for ind in range(n_data):
 
-            arts.add_data('ids', 1)
+            arts.add_data('ids', ind)
             arts.add_data('titles', 'title')
             arts.add_data('journals', ['science', 'sc'])
-            arts.add_data('authors', [('A', 'B', 'C', 'D')])
-            arts.add_data('words', 'Lots of words data.')
+            arts.add_data('authors', [['ln1', 'fn1', 'in1', 'af1'], ['ln2', 'fn2', 'in2', 'af2']])
+            arts.add_data('words', 'Lots of words data. Just a continuous text.')
             arts.add_data('keywords', ['lots', 'of', 'keywords'])
             arts.add_data('years', 2112)
             arts.add_data('dois', 'doi_str')
+
+    if add_none:
+        arts.dois[-1] = None
+        arts.years[-1] = None
+        arts.authors[-1] = None
+        arts.words[-1] = str()
+        arts.keywords[-1] = list()
 
     return arts
 

--- a/tutorials/plot_03-WordsCollection.py
+++ b/tutorials/plot_03-WordsCollection.py
@@ -54,7 +54,7 @@ words.add_terms(terms)
 ###################################################################################################
 
 # Collect words data
-words.run_collection(retmax='5')
+words.run_collection(retmax=5)
 
 ###################################################################################################
 # LISC Data Objects
@@ -140,7 +140,7 @@ words.add_terms(terms)
 db = SCDB('lisc_db')
 
 # Collect words data
-words.run_collection(usehistory=True, retmax='15', save_and_clear=True, directory=db)
+words.run_collection(usehistory=True, retmax=15, save_and_clear=True, directory=db)
 
 ###################################################################################################
 #

--- a/tutorials/plot_04-WordsAnalysis.py
+++ b/tutorials/plot_04-WordsAnalysis.py
@@ -85,6 +85,10 @@ arts_all.print_summary()
 #
 # The `results` attribute contains a list of :class:`~.Articles` objects, one for each term.
 #
+# If you run the :meth:`~.Words.process_combined_results` method, then the
+# `combined_results` attribute will contain the corresponding list of
+# :class:`~.ArticlesAll` objects, also one for each term.
+#
 
 ###################################################################################################
 
@@ -93,13 +97,13 @@ words = load_object('tutorial_words', directory=SCDB('lisc_db'), reload_results=
 
 ###################################################################################################
 
-# Convert collected data into aggregated data objects
-all_articles = [ArticlesAll(words[label]) for label in words.labels]
+# Process collected data into aggregated data objects
+words.process_combined_results()
 
 ###################################################################################################
 
 # Plot a WordCloud of the collected data for the first term
-plot_wordcloud(all_articles[0].words, 25)
+plot_wordcloud(words.combined_results[0].words, 25)
 
 ###################################################################################################
 # Exploring Words Data


### PR DESCRIPTION
This update mostly updates the process or article data, separating it out from the concatenation across articles done in ArticlesAll object, and includes various other updates, include fixing up words analysis functions and related data utilities. 

It also fixes an unrelated bug that meant that the defined retmax wasn't properly used in words collection when using history.