### PR TITLE
[MNT] - Update to support 3.11 / drop 3.6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,12 @@ on:
 jobs:
   build:
 
-    # Tag ubuntu version to 20.04, in order to support python 3.6
-    #   See issue: https://github.com/actions/setup-python/issues/544
-    #   When ready to drop 3.6, can revert from 'ubuntu-20.04' -> 'ubuntu-latest'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MODULE_NAME: lisc
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       # Because this repo launches requests, limit to one concurrent job at a time
       max-parallel: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
       MODULE_NAME: lisc
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        #python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.11"]
       # Because this repo launches requests, limit to one concurrent job at a time
       max-parallel: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,7 @@ jobs:
       MODULE_NAME: lisc
     strategy:
       matrix:
-        # Temp version only 3.11 - when working, switch to line below to test all versions
-        python-version: ["3.11"]
-        #python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       # Because this repo launches requests, limit to one concurrent job at a time
       max-parallel: 1
 

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ For a curated list of projects that use LISC check out the `projects <https://gi
 Dependencies
 ------------
 
-LISC is written in Python 3, and requires Python >= 3.6 to run.
+LISC is written in Python 3, and requires Python >= 3.7 to run.
 
 Requirements:
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Unix',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         ],
     platforms = 'any',
     keywords = ['web-scraping', 'meta-analysis', 'text-mining', 'scientific-publications',


### PR DESCRIPTION
This updates official support & testing to 3.11, and drops 3.6. 

Python 3.6 support is dropped because XX.
Note that in dropped 3.6, the workflow file can update to ubunto-latest.