### PR TITLE
[MNT] - Add Python 3.12 to workflow tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       MODULE_NAME: lisc
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       # Because this repo launches requests, limit to one concurrent job at a time
       max-parallel: 1
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ LISC - Literature Scanner
 .. |Publication| image:: https://joss.theoj.org/papers/10.21105/joss.01674/status.svg
 .. _Publication: https://doi.org/10.21105/joss.01674
 
-LISC is a package for collecting and analyzing the scientific literature.
+LISC is a package for collecting and analyzing scientific literature.
 
 Overview
 --------
@@ -33,7 +33,8 @@ Overview
 LISC acts as a wrapper and connector between available APIs, allowing users to collect data from and
 about scientific articles, and perform analyses on this data, such as performing automated meta-analyses.
 
-A curated list of some projects enabled by LISC is available on the `projects <https://github.com/lisc-tools/Projects>`_ page.
+A curated list of some projects enabled by LISC is available on the
+`projects <https://github.com/lisc-tools/Projects>`_ page.
 
 Supported APIs & Collection Approaches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -59,7 +60,8 @@ In addition to connecting to external APIs, LISC also provides:
 Documentation
 -------------
 
-Documentation is available on the `documentation site <https://lisc-tools.github.io/lisc/>`_.
+Documentation is available on the
+`documentation site <https://lisc-tools.github.io/lisc/>`_.
 
 This documentation includes:
 
@@ -72,7 +74,8 @@ This documentation includes:
 - `Reference <https://lisc-tools.github.io/lisc/reference.html>`_:
   with information for how to reference and report on using the module
 
-For a curated list of projects that use LISC check out the `projects <https://github.com/lisc-tools/Projects>`_ page.
+For a curated list of projects that use LISC, check out the
+`projects <https://github.com/lisc-tools/Projects>`_ page.
 
 Dependencies
 ------------

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         ],
     platforms = 'any',
     keywords = ['web-scraping', 'meta-analysis', 'text-mining', 'scientific-publications',


### PR DESCRIPTION
This looks like it will need to wait on an update from `wordcloud` - see: https://github.com/amueller/word_cloud/issues/730